### PR TITLE
fix "feature requests" (aka suggestions) link on contribute page

### DIFF
--- a/howto/contribute.md
+++ b/howto/contribute.md
@@ -45,7 +45,7 @@ When you are satisfied that you have a great fix to share with the world, commit
 Pull requests are thoroughly explained [here][9]. You will want to send a pull request to the Pinta repository from your fork. When the developers see your request, they will test your solution and if it is good they will merge it into the Pinta source code. They will then close the bug on Launchpad and add your name to the credits as a contributor, and you get a lovely warm feeling inside from helping make the world a better place!
 
 [1]: https://bugs.launchpad.net/pinta/+bugs
-[2]: /suggestions
+[2]: https://communiroo.com/pintaproject/pinta/suggestions
 [3]: https://translations.launchpad.net/pinta
 [4]: http://progit.org/book/
 [5]: https://github.com/PintaProject/Pinta


### PR DESCRIPTION
Just a little fix to "Pinta Feature Requests" link on Contribute page:
https://www.pinta-project.com/howto/contribute