### PR TITLE
Update Snapcraft URL to use new 'pinta' package

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -40,7 +40,7 @@ title: Download - Pinta
             <img src="images/snap.png" alt="Snap" width="48" height="48" />
             <p class="bullet" style="height: 60px">
               <span class="title">Linux (Snap)</span><br />
-              <a href="https://snapcraft.io/pinta-james-carroll" target="_blank">Download</a> | <a href="https://snapcraft.io/docs/installing-snapd" target="_blank">Setup Guide</a>
+              <a href="https://snapcraft.io/pinta" target="_blank">Download</a> | <a href="https://snapcraft.io/docs/installing-snapd" target="_blank">Setup Guide</a>
             </p>
             <img src="images/osx.png" alt="macOS" width="48" height="48" />
             <p class="bullet" style="height: 60px">


### PR DESCRIPTION
The existing package `pinta-james-carroll` is doing really well, having achieved 17,000 downloads in about 6 months. Whilst I'm happy to have my name tagged onto the project, it really makes more sense to have the package just called `pinta` pure incase I ever drop maintaining it, since it isn't technically possible to just replace an existing package. There's Snapcraft policies around names that meant I didn't do this originally, but the `pinta` package itself is live right now, `sudo snap install pinta` and `pinta` is basically all that's changed.

If you'd like, I can add you as a collaborator to the new snap package, Snapcraft uses Ubuntu SSO exactly like Launchpad, so if you wanted to make a Snapcraft account you can watch the users go up daily. 

Regarding the existing package, I'm conflicted on how to handle deprecating it. If I unpublish it from the store, existing installs won't be impacted at all so I'd imagine 99% of users won't notice, they'd likely eventually reinstall their systems and end up downloading the new one. I could technically keep pushing updates to both packages, but that's really just delaying the inevitable. Regardless, the old link will work at least until this PR is pulled, but shouldn't be visible on app stores since the new one is already live.

Cheers