### PR TITLE
Fix CSS selector for class on line 1863

### DIFF
--- a/css/pinta.css
+++ b/css/pinta.css
@@ -1860,7 +1860,7 @@ a.pinta-button,
     .pinta-headline .pinta-headline-container p {
         font-size: 30px;
     }
-    ..pinta-menu-rx-block .pinta-rx-designed {
+    .pinta-menu-rx-block .pinta-rx-designed {
         font-size: 45%;
         margin: 0 auto 0 0;
         padding: 0;

--- a/css/pinta.css
+++ b/css/pinta.css
@@ -1862,7 +1862,6 @@ a.pinta-button,
     }
     .pinta-menu-rx-block .pinta-rx-designed {
         font-size: 45%;
-        margin: 0 auto 0 0;
         padding: 0;
     }
     .pinta-menu-rx-block img:hover,


### PR DESCRIPTION
While browsing through the website source code, a syntax error was present on line 1863 of the source code. The " .pinta-menu-rx-block .pinta-rx-designed" selector, had an extra dot like:  "..pinta-menu-rx-block" which is invalid CSS.